### PR TITLE
Update raspberry.pp

### DIFF
--- a/manifests/maverick-modules/maverick_hardware/manifests/raspberry.pp
+++ b/manifests/maverick-modules/maverick_hardware/manifests/raspberry.pp
@@ -125,7 +125,7 @@ class maverick_hardware::raspberry (
                 unless      => "/bin/grep 'done' /etc/raspi-expandroot",
                 require	    => Package["raspi-config"],
             }
-            warning("Root filesystem/partition needs expanding, *please reboot* when configure is finished.")
+            warning("Root filesystem/partition needs expanding, *please stop configure* then expandrootfs using sudo raspi-config, and reboot before continuing.")
         }
     }
         


### PR DESCRIPTION
Modified the warning message for $expand_root, to prompt the user to expand_rootfs, then reboot before continuing maverick configure.

Since this is raspberry pi specific, it is advised to use the raspi-config tool.