### PR TITLE
Added Jetson Xavier NX support

### DIFF
--- a/conf/sample-nodes/maverick-xaviernx.json
+++ b/conf/sample-nodes/maverick-xaviernx.json
@@ -1,0 +1,46 @@
+// Sample/default config file for Nvidia Tegra (TK1/TX1/TK2) platform
+// Activated by changing hostname to 'maverick-tegra' and running 'maverick configure'
+{
+
+	// NOTE: Network configuration is defined in localconf.json, to keep settings private
+    "maverick_network::interfaces": {
+		"eth0": {}
+    },
+
+	// "maverick_intelligence::tensorflow": false, // Temporarily disabled until gpu build in place
+
+	// "maverick_intelligence::openkai": true,
+
+	// "base::desktop::enable": true,
+	
+	// Flight Controller (fc) mavlink setup
+	// "maverick_fc::mavlink_proxy": "mavproxy", // Default mavlink proxy type to use
+	// "maverick_fc::mavlink_active": true, // Whether the mavlink proxy is active or not
+	"maverick_fc::mavlink_input": "/dev/ttyTHS0", // Input source for mavlink proxy, how the Companion Computer connects to the Flight Controller
+	"maverick_fc::mavlink_inbaud": "921600", // Input baud rate for UART connections
+	// "maverick_fc::rosmaster_active": true, // Whether ROS master for fc is active or not
+	// "maverick_fc::mavros_active": true, // Whether Mavros for fc is active or not - requires fc rosmaster to be active
+
+	// Dev SITL mavlink setup - note this requires dev environment to be active
+	// "maverick_dev::apsitl_dev::mavlink_proxy": "mavproxy", // Default mavlink proxy type to use
+	// "maverick_dev::apsitl_dev::sitl_active": true, // Whether SITL is active or not
+	// "maverick_dev::apsitl_dev::mavlink_active": true, // Whether mavlink proxy is active or not
+	// "maverick_dev::apsitl_dev::rosmaster_active": true, // Whether ROS master for sitl is active or not
+	// "maverick_dev::apsitl_dev::mavros_active": true, // Whether Mavros for sitl is active or not - requires sitl rosmaster to be active
+
+	// "maverick_intelligence::redtail": true,
+	// "maverick_mavlink::mavcesium_active": true,
+	// "maverick_mavlink::mavcesium_mavlink_port": "5780",
+	
+	// "maverick_mavlink::cuav_install": true,
+	
+	// "maverick_vision::visiond::active": true,
+	// "maverick_vision::vision_landing::vision_landing_revision": "realsense",
+	// "maverick_vision::vision_landing::active": false,
+
+	// Add classes here
+	"classes":		[
+	    // "maverick_network"
+	]
+	
+}

--- a/manifests/maverick-modules/maverick_hardware/facts.d/tegra.py
+++ b/manifests/maverick-modules/maverick_hardware/facts.d/tegra.py
@@ -24,8 +24,10 @@ class Tegra(object):
                 board = f.readline().strip()
                 if board == "64":
                     self.data['model'] = 'TK1'
-                elif board == "33":
+                elif board == "33": # TK1 and Nano share the same tegra_chip_id 
                     self.data['model'] = 'TX1'
+                elif board == "25": # AGX and Xavier NX share the same tegra_chip_id 
+                    self.data['model'] = 'AGX'
                 elif board == "24":
                     self.data['model'] = 'TX2'
                 else:
@@ -38,6 +40,8 @@ class Tegra(object):
                 board = f.readline().strip()
                 if re.search('nano', board, re.IGNORECASE):
                     self.data['model'] = 'Jetson Nano'
+                elif re.search('xavier nx', board, re.IGNORECASE):
+                    self.data['model'] = 'Jetson Xavier NX'
         except:
             pass
         

--- a/manifests/maverick-modules/maverick_hardware/manifests/tegra.pp
+++ b/manifests/maverick-modules/maverick_hardware/manifests/tegra.pp
@@ -134,4 +134,12 @@ class maverick_hardware::tegra (
         }
     }
 
+    if $tegra_model == "Jetson Xavier NX" {
+        # Disables the nvgetty service which occupies the UART of the J12 header for the flight controller
+        exec { "tegra-disable-nvgetty":
+            command     => "/bin/systemctl stop nvgetty; sleep 10; /bin/systemctl disable nvgetty;",
+            onlyif      => "/bin/systemctl is-enabled nvgetty",
+        }
+    }
+
 }


### PR DESCRIPTION
Hi, this PR adds the detection of the Nvidia Jetson Xavier NX model (and probably the AGX-Xavier model as well since its tegra_chip_id is the same, although not tested) to the hardware detection step during the bootstrap configuration. It also adds some specific configurations useful for running Maverick on the Dev Kit.

Below is the error message occuring during bootstrap that led to this addition:

```
Error: Systemd start for maverick-motd failed!
journalctl log for maverick-motd:
-- Logs begin at Wed 2022-06-15 19:40:07 BST, end at Wed 2022-06-15 20:19:09 BST. --
Jun 15 20:19:05 ubuntu systemd[1]: Starting Maverick MOTD Creator...
Jun 15 20:19:09 ubuntu sh[7719]: Traceback (most recent call last):
Jun 15 20:19:09 ubuntu sh[7719]:   File "/srv/maverick/software/maverick/bin/maverick-info", line 92, in <module>
Jun 15 20:19:09 ubuntu sh[7719]:     print(twocols('Model', '\t\t\t' +tegra.data['model']))
Jun 15 20:19:09 ubuntu sh[7719]: TypeError: must be str, not NoneType
Jun 15 20:19:09 ubuntu systemd[1]: maverick-motd.service: Main process exited, code=exited, status=1/FAILURE
Jun 15 20:19:09 ubuntu systemd[1]: maverick-motd.service: Failed with result 'exit-code'.
Jun 15 20:19:09 ubuntu systemd[1]: Failed to start Maverick MOTD Creator.
```