### PR TITLE
Added missing field for Grafana mav user creation

### DIFF
--- a/manifests/maverick-modules/maverick_analysis/manifests/grafana.pp
+++ b/manifests/maverick-modules/maverick_analysis/manifests/grafana.pp
@@ -167,7 +167,7 @@ class maverick_analysis::grafana (
         # Create mav user in grafana
         exec { "grafana-mavuser":
             unless          => "/usr/bin/sqlite3 /srv/maverick/data/analysis/grafana/grafana.db 'select * from main.user' |grep mav",
-            command         => "/usr/bin/sqlite3 /srv/maverick/data/analysis/grafana/grafana.db \"insert into main.user values(100,0,'mav','mav','Maverick User','${mav_password}','${mav_salt}','yICOZzT82L','',10,0,0,'','2017-06-21 12:54:43','2017-06-21 12:54:43',1,'2017-06-21 12:54:43', 0)\"",
+            command         => "/usr/bin/sqlite3 /srv/maverick/data/analysis/grafana/grafana.db \"insert into main.user values(100,0,'mav','mav','Maverick User','${mav_password}','${mav_salt}','yICOZzT82L','',10,0,0,'','2017-06-21 12:54:43','2017-06-21 12:54:43',1,'2017-06-21 12:54:43',0,0)\"",
             user            => "mav",
         } ->
         # Delete old mav user link


### PR DESCRIPTION
Hi, this PR simply updates the command used to insert the mav user into the grafana database.

A field required for the creation of the mav user is missing when inserting it into the grafana.db database (probably the "is_service_account" field). This PR simply adds the missing field required to complete the Grafana configuration.

Below is the error that led to this modification:

```
Error: '/usr/bin/sqlite3 /srv/maverick/data/analysis/grafana/grafana.db "insert into main.user values(100,0,'mav','mav','Maverick User','e35f84e5859dfe5dfe2a9f6ed2086884c3a5e41d206c6e704b48cf45a0dda574ad85b4e9362e8d89eee3eb82e7ef34528ea4','ry48G1ZHyi','yICOZzT82L','',10,0,0,'','2017-06-21 12:54:43','2017-06-21 12:54:43',1,'2017-06-21 12:54:43', 0)"' returned 1 instead of one of [0]

Error: table main.user has 19 columns but 18 values were supplied
```